### PR TITLE
Add Control SoC Config

### DIFF
--- a/solarflow-control/config.yaml
+++ b/solarflow-control/config.yaml
@@ -20,6 +20,9 @@ options:
   smartmeter_type: "Smartmeter"
   full_charge_interval: 32
   control_bypass: true
+  control_soc: false
+  battery_low: 5
+  battery_high: 100
   mqtt_host: ""
   mqtt_user: ""
   mqtt_password: ""
@@ -49,6 +52,9 @@ schema:
   device_id: str
   full_charge_interval: int
   control_bypass: bool
+  control_soc: bool
+  battery_low: int
+  battery_high: int
   mqtt_host: str
   mqtt_port: port?
   mqtt_user: str?

--- a/solarflow-control/rootfs/etc/s6-overlay/s6-rc.d/init-solarflow-control/run
+++ b/solarflow-control/rootfs/etc/s6-overlay/s6-rc.d/init-solarflow-control/run
@@ -11,6 +11,7 @@ declare product_id
 declare device_id
 declare full_charge_interval
 declare control_bypass
+declare control_soc
 
 declare mqtt_host
 declare mqtt_port
@@ -46,6 +47,8 @@ declare latitude
 declare longitude
 declare sunrise_offset
 declare sunset_offset
+declare battery_low
+declare battery_high
 
 bashio::log.info 'Updating Solarflow Control configuration...'
 
@@ -66,6 +69,9 @@ sed -i "s|<full_charge_interval>|$full_charge_interval|g" /solarflow/config.ini
 
 control_bypass=$(bashio::config 'control_bypass')
 sed -i "s|<control_bypass>|$control_bypass|g" /solarflow/config.ini
+
+control_soc=$(bashio::config 'control_soc')
+sed -i "s|<control_soc>|$control_soc|g" /solarflow/config.ini
 
 mqtt_host=$(bashio::config 'mqtt_host')
 sed -i "s|<mqtt_host>|$mqtt_host|g" /solarflow/config.ini
@@ -149,3 +155,9 @@ sed -i "s|<sunrise_offset>|$sunrise_offset|g" /solarflow/config.ini
 
 sunset_offset=$(bashio::config 'sunset_offset')
 sed -i "s|<sunset_offset>|$sunset_offset|g" /solarflow/config.ini
+
+battery_low=$(bashio::config 'battery_low')
+sed -i "s|<battery_low>|$battery_low|g" /solarflow/config.ini
+
+battery_high=$(bashio::config 'battery_high')
+sed -i "s|<battery_high>|$battery_high|g" /solarflow/config.ini

--- a/solarflow-control/rootfs/solarflow/config.ini
+++ b/solarflow-control/rootfs/solarflow/config.ini
@@ -19,6 +19,9 @@ full_charge_interval = <full_charge_interval>
 # this overrides the automatic switching by the hub's firmware, which is sometimes a bit wierd
 control_bypass = <control_bypass>
 
+# allow solarflow-control to change the hubs min/max SoC levels if specified in this configuration in section [control] via battery_low and battery_high
+control_soc = <control_soc>
+
 [mqtt]
 # Your local MQTT host configuration
 mqtt_host = <mqtt_host>
@@ -90,3 +93,5 @@ longitude = <longitude>
 # Offset in minutes after sunrise/before sunset. Can be used to set the duration of what is considered "night"
 sunrise_offset = <sunrise_offset>
 sunset_offset = <sunset_offset>
+battery_low = <battery_low>
+battery_high = <battery_high>

--- a/solarflow-control/translations/en.yaml
+++ b/solarflow-control/translations/en.yaml
@@ -26,6 +26,11 @@ configuration:
     description: >-
       Let solarflow-control take over enabling/disabling the bypass of the hub (direct solarinput to hub output when
       battery is full) this overrides the automatic switching by the hub's firmware, which is sometimes a bit wierd.
+  control_soc:
+    name: Control SoC
+    description: >-
+      Allow solarflow-control to change the SolarFlow Hub's minimum and maxiumum battery levels which are considered
+      empty (stop discharging) or full (stop charging)
   mqtt_host:
     name: MQTT Host
     description: >-
@@ -141,3 +146,11 @@ configuration:
     name: Sunset Offset
     description: >-
       The offset in minutes after sunset. Can be used to set the duration of what is considered "night".
+  battery_low:
+    name: Battery Low
+    description: >-
+      The battery level when the Solarflow Hub will shutdown the battery and no longer allow furher discharging.
+  battery_high:
+    name: Battery High
+    description: >-
+      The battery level when the Solarflow Hub will consider the battery fully charged and stop further charging.


### PR DESCRIPTION
# Proposed Changes

Add the Control SoC configuration option to the add-on that was introduced with reinhard-brandstaedter/solarflow-control#274
