### PR TITLE
Add max_inverter_input config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 [contributors]: https://github.com/dfigus/addon-solarflow-control/graphs/contributors
-[docs]: https://github.com/dfigus/addon-solarflow-control/blob/main/tvheadend/DOCS.md
+[docs]: https://github.com/dfigus/addon-solarflow-control/blob/main/solarflow-control/DOCS.md
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg
 [forum]: https://community.home-assistant.io/
 [reinhard-brandstaedter]: https://github.com/reinhard-brandstaedter

--- a/solarflow-control/config.yaml
+++ b/solarflow-control/config.yaml
@@ -41,6 +41,7 @@ options:
   max_discharge_power: 150
   limit_inverter: true
   max_inverter_limit: 800
+  max_inverter_input: 700
   min_inverter_limit: 10
   discharge_during_daytime: false
   sunrise_offset: 60
@@ -77,6 +78,7 @@ schema:
   max_discharge_power: int?
   limit_inverter: bool?
   max_inverter_limit: int?
+  max_inverter_input: int?
   min_inverter_limit: int?
   discharge_during_daytime: bool?
   latitude: float?

--- a/solarflow-control/rootfs/etc/s6-overlay/s6-rc.d/init-solarflow-control/run
+++ b/solarflow-control/rootfs/etc/s6-overlay/s6-rc.d/init-solarflow-control/run
@@ -42,6 +42,7 @@ declare max_discharge_power
 declare limit_inverter
 declare max_inverter_limit
 declare min_inverter_limit
+declare max_inverter_input
 declare discharge_during_daytime
 declare latitude
 declare longitude
@@ -140,6 +141,9 @@ sed -i "s|<max_inverter_limit>|$max_inverter_limit|g" /solarflow/config.ini
 
 min_inverter_limit=$(bashio::config 'min_inverter_limit')
 sed -i "s|<min_inverter_limit>|$min_inverter_limit|g" /solarflow/config.ini
+
+max_inverter_input=$(bashio::config 'max_inverter_input')
+sed -i "s|<max_inverter_input>|$max_inverter_input|g" /solarflow/config.ini
 
 discharge_during_daytime=$(bashio::config 'discharge_during_daytime')
 sed -i "s|<discharge_during_daytime>|$discharge_during_daytime|g" /solarflow/config.ini

--- a/solarflow-control/rootfs/solarflow/config.ini
+++ b/solarflow-control/rootfs/solarflow/config.ini
@@ -4,6 +4,10 @@ dtu_type = <dtu_type>
 # Smartmeter Type: either Smartmeter (generic, Tasmota, Hichi, ...), PowerOpti, ShellyEM3
 smartmeter_type = <smartmeter_type>
 
+# Geolocation LAT/LNG
+latitude = <latitude>
+longitude = <longitude>
+
 [solarflow]
 # The product ID specifies the model of Solarflow hub to use: Hub-1200: "73bkTV" Hub-2000: "A8yh63"
 # defaults to 73bkTV
@@ -83,13 +87,15 @@ base_topic = <sm_shelly3em_base_topic>
 [control]
 min_charge_power = <min_charge_power>
 max_discharge_power = <max_discharge_power>
-discharge_during_daytime = <discharge_during_daytime>
+
+# the maximum power your inverter will feed to home
 max_inverter_limit = <max_inverter_limit>
+# the maximum power the hub would feed to the inverter channel, check with your inverter manual to avoid damage!
+max_inverter_input = <max_inverter_input>
 limit_inverter = <limit_inverter>
 inverter_min_limit = <min_inverter_limit>
-# Geolocation LAT/LNG
-latitude = <latitude>
-longitude = <longitude>
+
+discharge_during_daytime = <discharge_during_daytime>
 # Offset in minutes after sunrise/before sunset. Can be used to set the duration of what is considered "night"
 sunrise_offset = <sunrise_offset>
 sunset_offset = <sunset_offset>


### PR DESCRIPTION
# Proposed Changes

Add configuration option for `max_inverter_input` that was introduced with reinhard-brandstaedter/solarflow-control#314 and part of `solarflow-control` version 0.76

## Related Issues

> #40 