### PR TITLE
Fix missing AhoyDTU inverter name in the configuration

### DIFF
--- a/solarflow-control/config.yaml
+++ b/solarflow-control/config.yaml
@@ -30,6 +30,7 @@ options:
   inverter_max_power: 2000
   opendtu_inverter_serial: ""
   ahoydtu_inverter_id: "0"
+  ahoydtu_inverter_name: ""
   sm_generic_base_topic: ""
   sm_generic_cur_accessor: ""
   sm_generic_total_accessor: ""
@@ -65,6 +66,7 @@ schema:
   inverter_max_power: int?
   opendtu_inverter_serial: str?
   ahoydtu_inverter_id: int?
+  ahoydtu_inverter_name: str?
   sm_rapid_change_diff: int?
   sm_zero_offset: int?
   sm_scaling_factor: int?

--- a/solarflow-control/rootfs/etc/s6-overlay/s6-rc.d/init-solarflow-control/run
+++ b/solarflow-control/rootfs/etc/s6-overlay/s6-rc.d/init-solarflow-control/run
@@ -25,6 +25,7 @@ declare inverter_max_power
 
 declare opendtu_inverter_serial
 declare ahoydtu_inverter_id
+declare ahoydtu_inverter_name
 
 declare sm_rapid_change_diff
 declare sm_zero_offset
@@ -101,6 +102,9 @@ sed -i "s|<opendtu_inverter_serial>|$opendtu_inverter_serial|g" /solarflow/confi
 
 ahoydtu_inverter_id=$(bashio::config 'ahoydtu_inverter_id')
 sed -i "s|<ahoydtu_inverter_id>|$ahoydtu_inverter_id|g" /solarflow/config.ini
+
+ahoydtu_inverter_name=$(bashio::config 'ahoydtu_inverter_name')
+sed -i "s|<ahoydtu_inverter_name>|$ahoydtu_inverter_name|g" /solarflow/config.ini
 
 sm_rapid_change_diff=$(bashio::config 'sm_rapid_change_diff')
 sed -i "s|<sm_rapid_change_diff>|$sm_rapid_change_diff|g" /solarflow/config.ini

--- a/solarflow-control/rootfs/solarflow/config.ini
+++ b/solarflow-control/rootfs/solarflow/config.ini
@@ -58,7 +58,7 @@ sf_inverter_channels = <sf_inverter_channels>
 inverter_max_power = <inverter_max_power>
 
 # The name of the inverter in AhoyDTU
-#inverter_name = AhoyDTU
+inverter_name = <ahoydtu_inverter_name>
 
 [smartmeter]
 # rapid change difference defines the difference in W that has to be detected on the smartmeter readings to consider it a fast drop or rise in demand.

--- a/solarflow-control/translations/en.yaml
+++ b/solarflow-control/translations/en.yaml
@@ -68,6 +68,10 @@ configuration:
     name: AhoyDTU Inverter ID
     description: >-
       The ID of the inverter connected to the AhoyDTU.
+  ahoydtu_inverter_name:
+    name: AhoyDTU Inverter Name
+    description: >-
+      The name of the inverter in AhoyDTU.
   sm_rapid_change_diff:
     name: Smartmeter Rapid Change Difference
     description: >-
@@ -79,6 +83,11 @@ configuration:
     description: >-
       The zero offset defines the minimum power that is considered as a load. This is used to prevent the inverter
       from switching on/off when the smartmeter is reading a small amount of power (e.g. standby power)
+  sm_scaling_factor:
+    name: Smartmeter Scaling Factor
+    description: >-
+      The scaling factor is used to convert the smartmeter readings to the correct power values. This is used when
+      the smartmeter reports in a different unit than W.
   sm_generic_base_topic:
     name: Generic Smartmeter Base Topic
     description: >-


### PR DESCRIPTION
# Proposed Changes

The AhoyDTU inverter name was missing in the addon configuration which is required for using AhoyDTU.

## Related Issues

#48 
